### PR TITLE
Change from Docker Hub to Github Container Registry

### DIFF
--- a/gambas/Dockerfile
+++ b/gambas/Dockerfile
@@ -1,4 +1,4 @@
-FROM mdwagner/gambas:latest
+FROM ghcr.io/mdwagner/gambas:latest
 
 WORKDIR /root
 


### PR DESCRIPTION
I'm removing the docker hub version, but already moved it to github container registry. This should have no issues using the container.

new container link: https://github.com/users/mdwagner/packages/container/gambas/29932